### PR TITLE
When we use(in Cmake):

### DIFF
--- a/parser/CMakeLists.txt
+++ b/parser/CMakeLists.txt
@@ -151,6 +151,8 @@ SOURCE_GROUP("Header Files\\pe\\rsrc" FILES ${pe_rsrc_hdrs} )
 
 add_library ( bearparser STATIC ${parser_hdrs} ${parser_srcs} )
 
+target_include_directories(bearparser PUBLIC "${CMAKE_CURRENT_LIST_DIR}/include/")
+
 if(USE_QT4)
     target_link_libraries (bearparser ${QT_QTCORE_LIBRARIES} )
 else()


### PR DESCRIPTION
When we use(in Cmake):
  target_link_libraries(target  bearparser）

"Include/boreparser/" will be added to target's include directories, automatic.