### PR TITLE
[FEATURE] Recognize Thumb2 PE files

### DIFF
--- a/parser/include/bearparser/pe/pe_formats.h
+++ b/parser/include/bearparser/pe/pe_formats.h
@@ -200,6 +200,7 @@ enum file_machine {
     M_SH5 = 0x01a8,  // SH5
     M_ARM = 0x01c0,  // ARM Little-Endian
     M_THUMB = 0x01c2,
+    M_THUMB2 = 0x01c4, // ARM Thumb2
     M_AM33 = 0x01d3,
     M_POWERPC = 0x01F0,  // IBM PowerPC Little-Endian
     M_POWERPCFP = 0x01f1,

--- a/parser/pe/FileHdrWrapper.cpp
+++ b/parser/pe/FileHdrWrapper.cpp
@@ -79,6 +79,7 @@ void FileHdrWrapper::initMachine()
     s_machine[M_SH5] = "SH5";
     s_machine[M_ARM] = "ARM Little-Endian";
     s_machine[M_THUMB] = "Thumb";
+    s_machine[M_THUMB2] = "Thumb2";
     s_machine[M_AM33] = "AM33";
     s_machine[M_POWERPC] = "IBM PowerPC Little-Endian";
     s_machine[M_POWERPCFP] = "PowerRPCFP";


### PR DESCRIPTION
Recognize Thumb2 ISA used in Surface 1 and 2 ARMv7 devices.

[MSDN](https://learn.microsoft.com/en-us/windows/win32/sysinfo/image-file-machine-constants)